### PR TITLE
Fix schema.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This will get you set up with everything you need to test the app, and will auto
 However, you could use your own Solid Pod on any Solid Provider to send and receive calendar. Here are some of the popular ones to get started:
 
 - [Community Solid Server](https://solidweb.me)
-- [Solid Prototype](https://solidweb.org)
+- [Node Solid Server](https://solidweb.org)
 - [Solid Community](https://solidcommunity.net)
 - [Inrupt Pod Spaces](https://start.inrupt.com/profile)
 
@@ -41,17 +41,17 @@ The calendar events will be saved to "calendar-events" folder in your main conta
 
 # Event
 
-The ShEx shape used in this Solid App for the events in the calendar are of [Event](https://schema.org/Event/) type.
+The ShEx shape used in this Solid App for the events in the calendar are of [Event](https://schema.org/Event) type.
 
-The following properties are associated with this [Event](https://schema.org/Event/):
+The following properties are associated with this [Event](https://schema.org/Event):
 
-- organizer ([Person](https://schema.org/Person/))
+- organizer ([Person](https://schema.org/Person))
 - name ([String](https://www.w3.org/2001/XMLSchema#string))
 - startTime ([dateTime](https://www.w3.org/2001/XMLSchema#dateTime))
 - endTime ([dateTime](https://www.w3.org/2001/XMLSchema#dateTime))
-- attendees ([Person](https://schema.org/Person/))
-- location ([Place](https://schema.org/Place/))
-- about ([Thing](https://schema.org/Thing/))
+- attendees ([Person](https://schema.org/Person))
+- location ([Place](https://schema.org/Place))
+- about ([Thing](https://schema.org/Thing))
 
 ## Linting
 


### PR DESCRIPTION
1) https://schema.org/Event/ is a 404 but https://schema.org/Event works.

2) solidweb.org and other display "Welcome to the Solid prototype" but that welcome page was created when Node Solid Server was still *the* *only* Solid pod server prototype :) so naming it Node Solid Server is more accurate here.